### PR TITLE
Accuracy Improvements/chores

### DIFF
--- a/hyperbeam/hyperbeam-uptime.js
+++ b/hyperbeam/hyperbeam-uptime.js
@@ -125,8 +125,6 @@ function initializeApp() {
     const mainnetStatusContainer = document.getElementById('mainnetStatusContainer');
     
     if (mainnetContent) {
-        console.log("Mainnet content found:", mainnetContent);
-        console.log("Mainnet status container:", mainnetStatusContainer);
         
         if (!mainnetStatusContainer) {
             console.warn("Mainnet status container is missing! Creating it...");

--- a/hyperbeam/mainnet-node-list.js
+++ b/hyperbeam/mainnet-node-list.js
@@ -27,12 +27,48 @@ const mainnetNodes = [
         "country": "US"
     },
     {
+        "hb": "https://tee-5.forward.computer/",
+        "cu": "--",
+        "proxy": false,
+        "lat": 32.7889,
+        "lng": -96.8021,
+        "location": "Dallas, Texas, United States",
+        "country": "US"
+    },
+    {
+        "hb": "https://tee-6.forward.computer/",
+        "cu": "--",
+        "proxy": false,
+        "lat": 37.3931,
+        "lng": -121.962,
+        "location": "Santa Clara, California, United States",
+        "country": "US"
+    },
+    {
+        "hb": "https://tee-8.forward.computer/",
+        "cu": "--",
+        "proxy": false,
+        "lat": 34.0609,
+        "lng": -118.2414,
+        "location": "Los Angeles, California, United States",
+        "country": "US"
+    },
+    {
         "hb": "https://router-1.forward.computer/",
         "cu": "--",
         "proxy": false,
         "lat": 42.0048,
         "lng": -87.9954,
         "location": "Elk Grove Village, Illinois, United States",
+        "country": "US"
+    },
+    {
+        "hb": "https://dev-router.forward.computer/",
+        "cu": "--",
+        "proxy": false,
+        "lat": 34.0609,
+        "lng": -118.2414,
+        "location": "Los Angeles, California, United States",
         "country": "US"
     },
     {
@@ -73,21 +109,12 @@ const mainnetNodes = [
     },
     {
         "hb": "https://hb.arnode.asia/",
-        "cu": " https://cu.arnode.asia/",
+        "cu": "https://cu.arnode.asia/",
         "proxy": false,
         "lat": 19.0748,
         "lng": 72.8856,
         "location": "Mumbai, Maharashtra, India",
         "country": "IN"
-    },
-    {
-        "hb": "http://girls.onthewifi.com/",
-        "cu": "--",
-        "proxy": true,
-        "lat": 40.2662,
-        "lng": -83.2127,
-        "location": "Ostrander, Ohio, United States",
-        "country": "US"
     },
     {
         "hb": "https://hb.ao.p10node.com/",
@@ -135,15 +162,6 @@ const mainnetNodes = [
         "country": "DE"
     },
     {
-        "hb": "https://beam01.smartlabel.media/",
-        "cu": "https://cu01.smartlabel.media/",
-        "proxy": false,
-        "lat": 51.9435,
-        "lng": 4.40994,
-        "location": "Rotterdam, South Holland, The Netherlands",
-        "country": "NL"
-    },
-    {
         "hb": "https://guez.dev/",
         "cu": "--",
         "proxy": false,
@@ -151,24 +169,6 @@ const mainnetNodes = [
         "lng": 6.8624,
         "location": "Düsseldorf, North Rhine-Westphalia, Germany",
         "country": "DE"
-    },
-    {
-        "hb": "https://vixanator-hb.ngrok.io/",
-        "cu": "https://vixanator-cu.ngrok.io/",
-        "proxy": false,
-        "lat": 37.3394,
-        "lng": -121.895,
-        "location": "San Jose, California, United States",
-        "country": "US"
-    },
-    {
-        "hb": "http://185.177.124.64:10000/",
-        "cu": "--",
-        "proxy": true,
-        "lat": 51.9968,
-        "lng": 4.2057,
-        "location": "Naaldwijk, South Holland, The Netherlands",
-        "country": "NL"
     },
     {
         "hb": "http://38.58.182.4:10000/",
@@ -198,87 +198,6 @@ const mainnetNodes = [
         "country": "DE"
     },
     {
-        "hb": "http://161.97.111.21:10000/",
-        "cu": "http://161.97.111.21:6363/",
-        "proxy": true,
-        "lat": 48.9742,
-        "lng": 8.1851,
-        "location": "Lauterbourg, Grand Est, France",
-        "country": "FR"
-    },
-    {
-        "hb": "http://78.46.96.89:10000/",
-        "cu": "http://78.46.96.89:6363/",
-        "proxy": true,
-        "lat": 50.4777,
-        "lng": 12.3649,
-        "location": "Falkenstein, Saxony, Germany",
-        "country": "DE"
-    },
-    {
-        "hb": "http://173.249.55.161/",
-        "cu": "--",
-        "proxy": true,
-        "lat": 48.9742,
-        "lng": 8.1851,
-        "location": "Lauterbourg, Grand Est, France",
-        "country": "FR"
-    },
-    {
-        "hb": "http://65.21.104.103:10001/",
-        "cu": "--",
-        "proxy": true,
-        "lat": 60.1719,
-        "lng": 24.9347,
-        "location": "Helsinki, Uusimaa, Finland",
-        "country": "FI"
-    },
-    {
-        "hb": "http://149.50.96.91:8734/",
-        "cu": "--",
-        "proxy": true,
-        "lat": 52.2299,
-        "lng": 21.0093,
-        "location": "Warsaw, Mazovia, Poland",
-        "country": "PL"
-    },
-    {
-        "hb": "http://194.238.25.30:8734/",
-        "cu": "--",
-        "proxy": true,
-        "lat": 38.6364,
-        "lng": -90.1985,
-        "location": "St Louis, Missouri, United States",
-        "country": "US"
-    },
-    {
-        "hb": "http://65.109.105.164:10000/",
-        "cu": "--",
-        "proxy": true,
-        "lat": 60.1719,
-        "lng": 24.9347,
-        "location": "Helsinki, Uusimaa, Finland",
-        "country": "FI"
-    },
-    {
-        "hb": "http://159.69.187.12:10000/",
-        "cu": "--",
-        "proxy": true,
-        "lat": 50.4777,
-        "lng": 12.3649,
-        "location": "Falkenstein, Saxony, Germany",
-        "country": "DE"
-    },
-    {
-        "hb": "http://84.247.138.105:10000/",
-        "cu": "--",
-        "proxy": true,
-        "lat": 51.1864,
-        "lng": 6.8624,
-        "location": "Düsseldorf, North Rhine-Westphalia, Germany",
-        "country": "DE"
-    },
-    {
         "hb": "http://80.190.80.172:8734/",
         "cu": "--",
         "proxy": true,
@@ -288,33 +207,6 @@ const mainnetNodes = [
         "country": "GB"
     },
     {
-        "hb": "http://118.31.171.74:10000/",
-        "cu": "http://118.31.171.74:6363/",
-        "proxy": true,
-        "lat": 30.2943,
-        "lng": 120.1663,
-        "location": "Hangzhou, Zhejiang, China",
-        "country": "CN"
-    },
-    {
-        "hb": "http://89.58.48.48:10000/",
-        "cu": "--",
-        "proxy": true,
-        "lat": 49.4423,
-        "lng": 11.0191,
-        "location": "Nuremberg, Bavaria, Germany",
-        "country": "DE"
-    },
-    {
-        "hb": "http://62.72.42.125/",
-        "cu": "--",
-        "proxy": true,
-        "lat": 19.0748,
-        "lng": 72.8856,
-        "location": "Mumbai, Maharashtra, India",
-        "country": "IN"
-    },
-    {
         "hb": "http://65.109.27.148:10000/",
         "cu": "--",
         "proxy": true,
@@ -322,15 +214,6 @@ const mainnetNodes = [
         "lng": 24.9347,
         "location": "Helsinki, Uusimaa, Finland",
         "country": "FI"
-    },
-    {
-        "hb": "http://195.179.228.91:10001/",
-        "cu": "http://195.179.228.91:6363/",
-        "proxy": true,
-        "lat": 49.0078,
-        "lng": 8.4001,
-        "location": "Karlsruhe, Baden-Wurttemberg, Germany",
-        "country": "DE"
     },
     {
         "hb": "http://62.171.187.29:10001/",
@@ -351,24 +234,6 @@ const mainnetNodes = [
         "country": "FI"
     },
     {
-        "hb": "http://89.187.28.192:10001/",
-        "cu": "http://89.187.28.192:6363/",
-        "proxy": true,
-        "lat": 35.6893,
-        "lng": 139.6899,
-        "location": "Tokyo, Tokyo, Japan",
-        "country": "JP"
-    },
-    {
-        "hb": "http://152.53.87.198:9001/",
-        "cu": "http://152.53.87.198:9002/",
-        "proxy": true,
-        "lat": 49.4543,
-        "lng": 11.0746,
-        "location": "Nuremberg, Bavaria, Germany",
-        "country": "DE"
-    },
-    {
         "hb": "http://47.128.240.209:10001/",
         "cu": "http://47.128.240.209:6363/",
         "proxy": true,
@@ -376,78 +241,6 @@ const mainnetNodes = [
         "lng": 103.851,
         "location": "Singapore, Central Singapore, Singapore",
         "country": "SG"
-    },
-    {
-        "hb": "http://60.176.96.48:10000/",
-        "cu": "http://60.176.96.48:6363/",
-        "proxy": true,
-        "lat": 30.2943,
-        "lng": 120.1663,
-        "location": "Hangzhou, Zhejiang, China",
-        "country": "CN"
-    },
-    {
-        "hb": "http://89.117.60.148:10000/",
-        "cu": "http://89.117.60.148:6363/",
-        "proxy": true,
-        "lat": 51.1864,
-        "lng": 6.8624,
-        "location": "Düsseldorf, North Rhine-Westphalia, Germany",
-        "country": "DE"
-    },
-    {
-        "hb": "http://37.60.238.239:10000/",
-        "cu": "http://37.60.238.239:6363/",
-        "proxy": true,
-        "lat": 51.1864,
-        "lng": 6.8624,
-        "location": "Düsseldorf, North Rhine-Westphalia, Germany",
-        "country": "DE"
-    },
-    {
-        "hb": "http://95.217.3.46:10000/",
-        "cu": "http://95.217.3.46:6363/",
-        "proxy": true,
-        "lat": 60.1719,
-        "lng": 24.9347,
-        "location": "Helsinki, Uusimaa, Finland",
-        "country": "FI"
-    },
-    {
-        "hb": "http://65.108.255.207:10000/",
-        "cu": "http://65.108.255.207:6363/",
-        "proxy": true,
-        "lat": 60.1719,
-        "lng": 24.9347,
-        "location": "Helsinki, Uusimaa, Finland",
-        "country": "FI"
-    },
-    {
-        "hb": "http://95.217.134.254:10000/",
-        "cu": "http://95.217.134.254:6363/",
-        "proxy": true,
-        "lat": 60.1719,
-        "lng": 24.9347,
-        "location": "Helsinki, Uusimaa, Finland",
-        "country": "FI"
-    },
-    {
-        "hb": "http://37.27.91.213:10000/",
-        "cu": "http://37.27.91.213:6363/",
-        "proxy": true,
-        "lat": 60.1719,
-        "lng": 24.9347,
-        "location": "Helsinki, Uusimaa, Finland",
-        "country": "FI"
-    },
-    {
-        "hb": "http://144.126.129.12:10000/",
-        "cu": "http://144.126.129.12:6365/",
-        "proxy": true,
-        "lat": 38.6364,
-        "lng": -90.1985,
-        "location": "St Louis, Missouri, United States",
-        "country": "US"
     },
     {
         "hb": "http://95.216.248.117:10000/",
@@ -459,40 +252,13 @@ const mainnetNodes = [
         "country": "FI"
     },
     {
-        "hb": "http://8.148.68.114:10000/",
-        "cu": "http://8.148.68.114:6363/",
-        "proxy": true,
-        "lat": 30.2943,
-        "lng": 120.1663,
-        "location": "Hangzhou, Zhejiang, China",
-        "country": "CN"
-    },
-    {
-        "hb": "http://146.190.54.24:10001/",
-        "cu": "http://146.190.54.24:6363/",
+        "hb": "http://146.190.54.24:8734/",
+        "cu": "--",
         "proxy": true,
         "lat": 37.3931,
         "lng": -121.962,
         "location": "Santa Clara, California, United States",
         "country": "US"
-    },
-    {
-        "hb": "http://147.185.40.122:20047/",
-        "cu": "http://147.185.40.122:20045/",
-        "proxy": true,
-        "lat": 32.7767,
-        "lng": -96.797,
-        "location": "Dallas, Texas, United States",
-        "country": "US"
-    },
-    {
-        "hb": "http://161.97.167.146:10000/",
-        "cu": "--",
-        "proxy": true,
-        "lat": 51.1864,
-        "lng": 6.8624,
-        "location": "Düsseldorf, North Rhine-Westphalia, Germany",
-        "country": "DE"
     },
     {
         "hb": "http://65.109.91.146:10000/",
@@ -513,42 +279,6 @@ const mainnetNodes = [
         "country": "CA"
     },
     {
-        "hb": "http://8.148.230.133:10000/",
-        "cu": "http://8.148.230.133:6363/",
-        "proxy": true,
-        "lat": 23.1181,
-        "lng": 113.2539,
-        "location": "Guangzhou, Guangdong, China",
-        "country": "CN"
-    },
-    {
-        "hb": "http://27.72.31.207:10000/",
-        "cu": "--",
-        "proxy": true,
-        "lat": 21.0184,
-        "lng": 105.8461,
-        "location": "Hanoi, Hanoi, Vietnam",
-        "country": "VN"
-    },
-    {
-        "hb": "http://45.76.89.152:10000/",
-        "cu": "http://45.76.89.152:6363/",
-        "proxy": true,
-        "lat": 50.1103,
-        "lng": 8.7147,
-        "location": "Frankfurt am Main, Hesse, Germany",
-        "country": "DE"
-    },
-    {
-        "hb": "http://121.43.32.111:10000/",
-        "cu": "http://121.43.32.111:6363/",
-        "proxy": true,
-        "lat": 30.2943,
-        "lng": 120.1663,
-        "location": "Hangzhou, Zhejiang, China",
-        "country": "CN"
-    },
-    {
         "hb": "http://207.180.227.138:10000/",
         "cu": "http://207.180.227.138:6363/",
         "proxy": true,
@@ -556,15 +286,6 @@ const mainnetNodes = [
         "lng": 8.1851,
         "location": "Lauterbourg, Grand Est, France",
         "country": "FR"
-    },
-    {
-        "hb": "http://185.174.164.162:10000/",
-        "cu": "http://185.174.164.162:6363/",
-        "proxy": true,
-        "lat": 59.9311,
-        "lng": 30.3609,
-        "location": "St Petersburg, St.-Petersburg, Russia",
-        "country": "RU"
     },
     {
         "hb": "http://95.111.252.179:10000/",
@@ -583,24 +304,6 @@ const mainnetNodes = [
         "lng": 8.1851,
         "location": "Lauterbourg, Grand Est, France",
         "country": "FR"
-    },
-    {
-        "hb": "http://202.61.201.187:10001/",
-        "cu": "http://202.61.201.187:6363/",
-        "proxy": true,
-        "lat": 49.4423,
-        "lng": 11.0191,
-        "location": "Nuremberg, Bavaria, Germany",
-        "country": "DE"
-    },
-    {
-        "hb": "http://118.178.135.71:10000/",
-        "cu": "http://118.178.135.71:6363/",
-        "proxy": true,
-        "lat": 30.2943,
-        "lng": 120.1663,
-        "location": "Hangzhou, Zhejiang, China",
-        "country": "CN"
     },
     {
         "hb": "http://213.160.68.7:10001/",
@@ -639,51 +342,6 @@ const mainnetNodes = [
         "country": "FR"
     },
     {
-        "hb": "http://8.134.178.40:10000/",
-        "cu": "http://8.134.178.40:6363/",
-        "proxy": true,
-        "lat": 23.1181,
-        "lng": 113.2539,
-        "location": "Guangzhou, Guangdong, China",
-        "country": "CN"
-    },
-    {
-        "hb": "http://194.163.188.221:10000/",
-        "cu": "http://194.163.188.221:6363/",
-        "proxy": true,
-        "lat": 51.1864,
-        "lng": 6.8624,
-        "location": "Düsseldorf, North Rhine-Westphalia, Germany",
-        "country": "DE"
-    },
-    {
-        "hb": "http://185.218.126.59:10000/",
-        "cu": "http://185.218.126.59:6363/",
-        "proxy": true,
-        "lat": 51.1864,
-        "lng": 6.8624,
-        "location": "Düsseldorf, North Rhine-Westphalia, Germany",
-        "country": "DE"
-    },
-    {
-        "hb": "http://149.102.138.138:10000/",
-        "cu": "--",
-        "proxy": true,
-        "lat": 51.1864,
-        "lng": 6.8624,
-        "location": "Düsseldorf, North Rhine-Westphalia, Germany",
-        "country": "DE"
-    },
-    {
-        "hb": "http://83.171.248.176:10000/",
-        "cu": "http://83.171.248.176:6363/",
-        "proxy": true,
-        "lat": 51.1864,
-        "lng": 6.8624,
-        "location": "Düsseldorf, North Rhine-Westphalia, Germany",
-        "country": "DE"
-    },
-    {
         "hb": "http://95.111.238.178:10000/",
         "cu": "http://95.111.238.178:6363/",
         "proxy": true,
@@ -693,14 +351,24 @@ const mainnetNodes = [
         "country": "FR"
     },
     {
-        "hb": "http://194.233.86.27:10000/",
+        "hb": "http://ao1.decentralizedinfra.com:10000/",
         "cu": "--",
         "proxy": true,
-        "lat": 1.2821,
-        "lng": 103.851,
-        "location": "Singapore, Central Singapore, Singapore",
-        "country": "SG"
+        "lat": 29.7604,
+        "lng": -95.3698,
+        "location": "Houston, Texas, United States",
+        "country": "US"
+    },
+    {
+        "hb": "http://161.97.126.148:8734/",
+        "cu": "--",
+        "proxy": true,
+        "lat": 48.9742,
+        "lng": 8.1851,
+        "location": "Lauterbourg, Grand Est, France",
+        "country": "FR"
     }
 ];
 
 export { mainnetNodes };
+ 

--- a/hyperbeam/pachage.json
+++ b/hyperbeam/pachage.json
@@ -1,0 +1,9 @@
+{
+  "name": "node-checker",
+  "version": "1.0.0",
+  "type": "module",
+  "dependencies": {
+    "express": "^4.18.2",
+    "cors": "^2.8.5"
+  }
+}

--- a/hyperbeam/worker.js
+++ b/hyperbeam/worker.js
@@ -1,0 +1,197 @@
+import express from 'express';
+import cors from 'cors';
+import { fetch } from 'undici';
+import { mainnetNodes } from './mainnet-node-list.js';
+
+const app = express();
+app.use(cors({
+  origin: true,
+  credentials: true,
+  methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
+  allowedHeaders: ['Content-Type', 'Authorization', 'Origin', 'X-Requested-With', 'Accept']
+}));
+
+// Authorization patterns
+const GATEWAY_PATTERN = /^https:\/\/eye-of-ao\.[^\/]+/i;
+const LOCAL_ALLOWLIST = [
+  "localhost:8080",
+  "localhost"
+];
+
+// Node monitoring cache
+const nodeStatusCache = new Map();
+let lastUpdateTime = null;
+
+// Extract both HyperBEAM and CU URLs from your mainnet node list (only proxy nodes)
+const NODES_TO_MONITOR = [];
+
+mainnetNodes
+  .forEach(node => {
+    // Always add HB node
+    NODES_TO_MONITOR.push(node.hb);
+    
+    // Add CU node if it exists and isn't "--"
+    if (node.cu && node.cu !== "--") {
+      NODES_TO_MONITOR.push(node.cu);
+    }
+  });
+
+function isAuthorizedReferrer(header) {
+  if (!header) return false;
+
+  // Allow eye-of-ao.*
+  if (GATEWAY_PATTERN.test(header)) return true;
+
+  // DOMAIN routing
+  if (header.includes("hyperbeam-uptime.xyz")) return true;
+
+//----------- Local dev support------------------
+  return LOCAL_ALLOWLIST.some(prefix => header.includes(prefix));
+}
+
+
+async function tryRequestWithin5s(targetUrl) {
+  const start = Date.now();
+
+  const attempt = fetch(targetUrl, {
+    method: "GET",
+    redirect: "follow"
+  }).then(async (res) => {
+    const status = res.status;
+    const responseTime = Date.now() - start;
+    const isOnline = status >= 200 && status < 400;
+
+    return {
+      online: isOnline,
+      status,
+      responseTime
+    };
+  }).catch((err) => {
+    return {
+      online: false,
+      error: err.message,
+      responseTime: Date.now() - start
+    };
+  });
+
+  const timeout = new Promise(resolve => {
+    setTimeout(() => {
+      resolve({
+        online: false,
+        error: "Timeout after 5 seconds",
+        responseTime: 5000
+      });
+    }, 5000);
+  });
+
+  return Promise.race([attempt, timeout]);
+}
+
+async function checkAllNodes() {
+  console.log(`🔄 Starting parallel checks for ${NODES_TO_MONITOR.length} nodes at ${new Date().toISOString()}`);
+  const startTime = Date.now();
+  
+  // Check all nodes in parallel
+  const checkPromises = NODES_TO_MONITOR.map(async (nodeUrl) => {
+    try {
+      const result = await tryRequestWithin5s(nodeUrl);
+      nodeStatusCache.set(nodeUrl, {
+        ...result,
+        lastChecked: Date.now(),
+        url: nodeUrl
+      });
+      console.log(`✓ ${nodeUrl}: ${result.online ? 'online' : 'offline'} (${result.responseTime}ms)`);
+      return { nodeUrl, success: true, result };
+    } catch (error) {
+      nodeStatusCache.set(nodeUrl, {
+        online: false,
+        error: error.message,
+        responseTime: 5000,
+        lastChecked: Date.now(),
+        url: nodeUrl
+      });
+      console.log(`✗ ${nodeUrl}: error - ${error.message}`);
+      return { nodeUrl, success: false, error: error.message };
+    }
+  });
+  
+  // Wait for all checks to complete
+  await Promise.allSettled(checkPromises);
+  
+  const totalTime = Date.now() - startTime;
+  lastUpdateTime = Date.now();
+  console.log(`✅ All node checks completed in ${(totalTime/1000).toFixed(1)}s at ${new Date().toISOString()}`);
+}
+
+// Main endpoint - returns cached status for specific node
+app.get('/', async (req, res) => {
+  const referer = req.headers.referer || "";
+  const origin = req.headers.origin || "";
+  const authorized = isAuthorizedReferrer(referer) || isAuthorizedReferrer(origin);
+
+  if (!authorized) {
+    return res.status(403).json({
+      online: false,
+      error: "Unauthorized request origin"
+    });
+  }
+
+  const target = req.query.url;
+  if (!target || !/^http/.test(target)) {
+    return res.status(400).json({
+      online: false,
+      error: "Invalid or missing URL"
+    });
+  }
+
+  // Return cached result if available
+  const cachedResult = nodeStatusCache.get(target);
+  if (cachedResult) {
+    return res.status(200).json({
+      ...cachedResult,
+      cached: true,
+      lastChecked: new Date(cachedResult.lastChecked).toISOString()
+    });
+  }
+
+  // If not in cache, return error (node not monitored)
+  res.status(404).json({
+    online: false,
+    error: "Node not found in monitoring list",
+    cached: false
+  });
+});
+
+// Optional: Get all cached statuses
+app.get('/status', (req, res) => {
+  const referer = req.headers.referer || "";
+  const origin = req.headers.origin || "";
+  const authorized = isAuthorizedReferrer(referer) || isAuthorizedReferrer(origin);
+
+  if (!authorized) {
+    return res.status(403).json({ error: "Unauthorized request origin" });
+  }
+
+  const allStatuses = Array.from(nodeStatusCache.values());
+  const onlineCount = allStatuses.filter(s => s.online).length;
+  
+  res.json({
+    lastUpdate: lastUpdateTime ? new Date(lastUpdateTime).toISOString() : null,
+    totalNodes: allStatuses.length,
+    onlineNodes: onlineCount,
+    offlineNodes: allStatuses.length - onlineCount,
+    statuses: allStatuses
+  });
+});
+
+// Start background monitoring
+const hbCount = mainnetNodes.filter(node => node.proxy === true).length;
+const cuCount = mainnetNodes.filter(node => node.proxy === true && node.cu && node.cu !== "--").length;
+console.log(`📋 Monitoring ${NODES_TO_MONITOR.length} total endpoints: ${hbCount} HyperBEAM + ${cuCount} CU nodes`);
+checkAllNodes(); // Initial check
+setInterval(checkAllNodes, 2 * 60 * 1000); // Check every 5 minutes
+
+app.listen(3000, () => {
+  console.log('✅ Server running on http://localhost:3000');
+  console.log('🔄 Background node monitoring active (5min intervals)');
+});


### PR DESCRIPTION
Created a server that caches the uptime of ALL nodes every 2 minutes. This is MUCH more accurate showing the uptime stats. The issues with communicating from a https browser to nodes/http endpoints presented too many issues so its all now neatly offloaded and cleaned up.

Removed chronically offline nodes from the lists.

Added Busy sign to nodes on the 3D globe with the new setup.

Also added several new nodes that are online.

Next Chores:
Update "Custom Nodes" dashboard on HyperBEAM. May possibly remove this feature. It is cumbersome to keep working and doesn't get used much really.